### PR TITLE
support "created_by" option in file header

### DIFF
--- a/Sources/Rules.swift
+++ b/Sources/Rules.swift
@@ -3774,7 +3774,7 @@ public struct _FormatRules {
     ) { formatter in
         guard !formatter.options.fragment else { return }
 
-        let header: String
+        var header: String
         switch formatter.options.fileHeader {
         case .ignore:
             return
@@ -3862,6 +3862,30 @@ public struct _FormatRules {
                 break
             }
         }
+
+        if let range = header.range(of: "{created_by}") {
+            // replace {created_by} with the line "Created by ..." in the original headers if have.
+            var createdByComment: String?
+            let createdByCommentTokenIndex = formatter.index(before: lastHeaderTokenIndex, where: {
+                if case let .commentBody(comment) = $0 {
+                    if comment.hasPrefix("Created by") {
+                        createdByComment = comment
+                        return true
+                    }
+                }
+                return false
+            })
+
+            if let createdByComment = createdByComment {
+                header.replaceSubrange(range, with: createdByComment)
+            } else {
+                // remove {created_by} line
+                let lineBegin = header.index(range.lowerBound, offsetBy: -3)
+                let lineEnd = header.index(range.upperBound, offsetBy: 1)
+                header.replaceSubrange(lineBegin ..< lineEnd, with: "")
+            }
+        }
+
         if header.isEmpty {
             formatter.removeTokens(in: 0 ..< lastHeaderTokenIndex + 1)
             return

--- a/Sources/SwiftFormat.swift
+++ b/Sources/SwiftFormat.swift
@@ -505,19 +505,35 @@ private func applyRules(
 
     // Check if required FileInfo is available
     if rules.contains(FormatRules.fileHeader) {
-        if options.fileHeader.rawValue.contains("{created"),
+        if options.fileHeader.rawValue.contains("{created}"),
            options.fileInfo.creationDate == nil
         {
             throw FormatError.options(
                 "Failed to apply {created} template in file header as file info is unavailable"
             )
         }
-        if options.fileHeader.rawValue.contains("{file"),
+        if options.fileHeader.rawValue.contains("{file}"),
            options.fileInfo.fileName == nil
         {
             throw FormatError.options(
                 "Failed to apply {file} template in file header as file name was not provided"
             )
+        }
+        if let range = options.fileHeader.rawValue.range(of: "{created_by}") {
+            // "// {created_by}\n" must be in a separated line.
+            let lineBegin = options.fileHeader.rawValue.index(range.lowerBound, offsetBy: -3)
+            let prefix = options.fileHeader.rawValue[lineBegin ..< range.lowerBound]
+            if prefix != "// " {
+                throw FormatError.options(
+                    "Failed to apply {created_by} template in file header as {created_by} should be used in '// {created_by}\n' exclusively."
+                )
+            }
+            let lineEnd = options.fileHeader.rawValue.index(range.upperBound, offsetBy: 2)
+            if options.fileHeader.rawValue[range.upperBound ..< lineEnd] != "\\n" {
+                throw FormatError.options(
+                    "Failed to apply {created_by} template in file header as {created_by} should be used in '// {created_by}\n' exclusively."
+                )
+            }
         }
     }
 

--- a/Tests/RulesTests.swift
+++ b/Tests/RulesTests.swift
@@ -1886,6 +1886,76 @@ class RulesTests: XCTestCase {
         XCTAssertThrowsError(try format(input, rules: [FormatRules.fileHeader], options: options))
     }
 
+    func testFileHeaderWithPreserveCreatedByComment() {
+        let input = """
+        //
+        // AppDelegate.swift
+        // Module
+        //
+        // Created by Nick Lockwood on 12/08/2016.
+        // Copyright © 2019 ChouTi. All rights reserved.
+        //
+
+        import UIKit
+
+        enum A {}
+
+        """
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy"
+
+        let output = """
+        //
+        // MyFile.swift
+        //
+        // Created by Nick Lockwood on 12/08/2016.
+        // Copyright © \(formatter.string(from: Date())) Nick Lockwood. All rights reserved.
+        //
+
+        import UIKit
+
+        enum A {}
+
+        """
+        let options = FormatOptions(fileHeader: "//\n// {file}\n//\n// {created_by}\n// Copyright © {year} Nick Lockwood. All rights reserved.\n//", fileInfo: FileInfo(filePath: "~/MyFile.swift"))
+        testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
+    }
+
+    func testFileHeaderWithPreserveCreatedByCommentIfNoCreatedLine() {
+        let input = """
+        //
+        // AppDelegate.swift
+        // Module
+        //
+        // Copyright © 2019 ChouTi. All rights reserved.
+        //
+
+        import UIKit
+
+        enum A {}
+
+        """
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy"
+
+        let output = """
+        //
+        // MyFile.swift
+        //
+        // Copyright © \(formatter.string(from: Date())) Nick Lockwood. All rights reserved.
+        //
+
+        import UIKit
+
+        enum A {}
+
+        """
+        let options = FormatOptions(fileHeader: "//\n// {file}\n//\n// {created_by}\n// Copyright © {year} Nick Lockwood. All rights reserved.\n//", fileInfo: FileInfo(filePath: "~/MyFile.swift"))
+        testFormatting(for: input, output, rule: FormatRules.fileHeader, options: options)
+    }
+
     // MARK: - sortedSwitchCases
 
     func testSortedSwitchCaseMultilineWithComments() {

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -753,6 +753,8 @@ extension RulesTests {
         ("testFileHeaderFileReplacement", testFileHeaderFileReplacement),
         ("testFileHeaderRuleThrowsIfCreationDateUnavailable", testFileHeaderRuleThrowsIfCreationDateUnavailable),
         ("testFileHeaderRuleThrowsIfFileNameUnavailable", testFileHeaderRuleThrowsIfFileNameUnavailable),
+        ("testFileHeaderWithPreserveCreatedByComment", testFileHeaderWithPreserveCreatedByComment),
+        ("testFileHeaderWithPreserveCreatedByCommentIfNoCreatedLine", testFileHeaderWithPreserveCreatedByCommentIfNoCreatedLine),
         ("testFileHeaderYearReplacement", testFileHeaderYearReplacement),
         ("testFileprivateClassMemberChangedToPrivateEvenIfConstructorCalledOutsideType", testFileprivateClassMemberChangedToPrivateEvenIfConstructorCalledOutsideType),
         ("testFileprivateClassTypeMemberNotChangedToPrivate", testFileprivateClassTypeMemberNotChangedToPrivate),


### PR DESCRIPTION
Can use:
```
--header "//\n// {file}\n//\n// {created_by}\n// Copyright © {year} Example. All rights reserved.\n//" 
```
to preserve the line of `Created by Steve Jobs on 11/08/2011.`

Must use `// {created_by}\n` in a separated line in the template, if the original file header doesn't have `Created by ...` comment, this line is ignored.